### PR TITLE
Change text counting to ignore Markdown syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,21 +142,24 @@ document.getElementById('clipboard-btn').addEventListener('click', async() => {
 });
 
 /**
- * Updates the character count display.
- * It shows both the total number of characters (excluding newline and unescaped <br> tags)
+ * Updates the character count display based on the WYSIWYG content (HTML),
+ * ignoring Markdown syntax.
+ * It shows both the total number of characters (rendered text only)
  * and the number of characters in the current selection.
  */
 function updateCount() {
   const editor = getEditorInstance();
   if (!editor) return;
-  const total = editor.getMarkdown()
-    .replace(/\n/g, '')
-    .replace(/(?<!\\)<br>/g, '')
-    .length;
-  const selection = window.getSelection().toString()
-    .replace(/\n/g, '')
-    .replace(/(?<!\\)<br>/g, '')
-    .length;
+  const rawHtml = editor.getHTML();
+
+  const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+  const totalText = doc.body.textContent || '';
+
+  const total = totalText.replace(/\n/g, '').length;
+
+  const selectionText = window.getSelection().toString() || '';
+  const selection = selectionText.replace(/\n/g, '').length;
+
   const countElem = document.getElementById('count');
   countElem.innerText = `Total Characters: ${total}, Selected Characters: ${selection}`;
 }


### PR DESCRIPTION
This commit modifies the method used to count characters by removing Markdown tokens (such as `**`'or `_`) from the total. As a result, the character count now reflects the actual text content rather than including formatting symbols.
