### PR TITLE
Remove toggle-case OFF style

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -164,7 +164,7 @@
         <input id="search-input" type="text" placeholder="Enter search text"
           class="flex-1 p-2 border border-gray-300 dark:bg-gray-800 dark:border-gray-600 rounded" />
         <button id="toggle-case-btn"
-          class="ml-2 p-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
+          class="ml-2 p-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-blue-200 dark:hover:bg-blue-700">
           <svg width="20" height="20" fill="currentColor">
             <use xlink:href="#isCaseSensitive"></use>
           </svg>

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -60,8 +60,8 @@ export function setupSearch(textDB) {
 
   toggleCaseBtn.addEventListener('click', () => {
     caseSensitive = !caseSensitive;
-    toggleCaseBtn.classList.toggle('bg-blue-100', caseSensitive);
-    toggleCaseBtn.classList.toggle('bg-red-100', !caseSensitive);
+    toggleCaseBtn.classList.toggle('bg-blue-300', caseSensitive);
+    toggleCaseBtn.classList.toggle('dark:bg-blue-500', caseSensitive);
     performSearch();
   });
 


### PR DESCRIPTION
This commit removes the alternate background color for the toggle-case button when case sensitivity is OFF. The button now shows only the blue style (bg-blue-300 / dark:bg-blue-500) when case sensitivity is enabled.
