### PR TITLE
Fix viewport meta for small screens

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - release/**
+      - release/2.0.0-alpha3 
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
       - release/**
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/**
 
 jobs:
   build-and-deploy:

--- a/src/index.html
+++ b/src/index.html
@@ -3,11 +3,17 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Memo App</title>
   <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/toastui-editor.min.css">
   <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/theme/toastui-editor-dark.min.css">
   <link rel="stylesheet" href="./styles/tailwind.css">
   <link rel="stylesheet" href="./styles/base.css">
+  <script>
+    (function() {
+      if (window.innerWidth < 480) document.querySelector("meta[name=viewport]").setAttribute("content", "width=480, user-scalable=no");
+    })();
+  </script>
 </head>
 
 <body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-white">


### PR DESCRIPTION
This PR introduces a JavaScript snippet that dynamically adjusts the viewport meta tag. When a device’s screen width is less than 480px, the script sets the viewport to a fixed width of 480px with user scaling disabled. This ensures that the layout is rendered consistently on smaller screens, while devices with widths of 480px or more continue to use the default responsive settings.
