### PR TITLE
Remove Editor Re-Creation on Window Resize

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - release/2.0.0-alpha3 
 
 jobs:
   build-and-deploy:

--- a/src/index.js
+++ b/src/index.js
@@ -115,12 +115,6 @@ document.getElementById('close-search-btn').addEventListener('click', () => {
   searchModal.classList.add('hidden');
 });
 
-// Listen for window resize events and update the editor's height accordingly
-window.addEventListener('resize', () => {
-  updateEditor();
-  updateCount();
-});
-
 // Listen for selection changes to update the character count display and reset clipboard icon
 document.addEventListener('selectionchange', () => {
   updateCount();


### PR DESCRIPTION
Observed on mobile devices that triggering a resize event (e.g., when the keyboard is displayed) causes the editor to be re-created, leading to unstable cursor positioning and rapid toggling of the keyboard. This functionality appears rarely needed and adversely affects user experience on mobile, so removing automatic editor re-creation on resize events seems beneficial.