### PR TITLE
Add Code Syntax Highlight Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Ymmy833y",
   "dependencies": {
     "@toast-ui/editor": "^3.1.0",
+    "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
     "@toast-ui/editor-plugin-color-syntax": "^3.1.0",
     "@toast-ui/editor-plugin-uml": "^3.0.1"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,8 @@
   <link rel="stylesheet" href="https://uicdn.toast.com/editor/latest/theme/toastui-editor-dark.min.css">
   <link rel="stylesheet" href="https://uicdn.toast.com/tui-color-picker/latest/tui-color-picker.min.css">
   <link rel="stylesheet" href="https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css">
+  <link rel="stylesheet" href="https://uicdn.toast.com/editor-plugin-code-syntax-highlight/latest/toastui-editor-plugin-code-syntax-highlight.min.css">
   <link rel="stylesheet" href="./styles/tailwind.css">
   <link rel="stylesheet" href="./styles/base.css">
   <link rel="manifest" href="./manifest.json">

--- a/src/services/editor.js
+++ b/src/services/editor.js
@@ -1,5 +1,6 @@
 import Editor from '@toast-ui/editor';
 import colorSyntax from '@toast-ui/editor-plugin-color-syntax';
+import codeSyntaxHighlight from '@toast-ui/editor-plugin-code-syntax-highlight/dist/toastui-editor-plugin-code-syntax-highlight-all.js';
 import uml from '@toast-ui/editor-plugin-uml';
 import { getCurrentTheme } from './theme.js';
 
@@ -28,7 +29,7 @@ export function createEditor(initialValue = '') {
     previewStyle: 'vertical',
     theme: currentTheme,
     initialValue,
-    plugins: [colorSyntax, uml],
+    plugins: [colorSyntax, codeSyntaxHighlight, uml],
   });
   return editorInstance;
 }
@@ -50,7 +51,7 @@ export function updateEditor() {
     previewStyle: 'vertical',
     theme: currentTheme,
     initialValue: content,
-    plugins: [colorSyntax],
+    plugins: [colorSyntax, codeSyntaxHighlight, uml],
   });
 }
 

--- a/src/sw.js
+++ b/src/sw.js
@@ -6,7 +6,9 @@ const CDN_URLS = [
   'https://uicdn.toast.com/editor/latest/toastui-editor.min.css',
   'https://uicdn.toast.com/editor/latest/theme/toastui-editor-dark.min.css',
   'https://uicdn.toast.com/tui-color-picker/latest/tui-color-picker.min.css',
-  'https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.css'
+  'https://uicdn.toast.com/editor-plugin-color-syntax/latest/toastui-editor-plugin-color-syntax.min.css',
+  'https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/themes/prism.min.css',
+  'https://uicdn.toast.com/editor-plugin-code-syntax-highlight/latest/toastui-editor-plugin-code-syntax-highlight.min.css'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
Integrated the TOAST UI Editor code syntax highlight plugin into MemoApp.

However, it doesn't seem to be optimized for the dark theme.