### PR TITLE
Fix style removal process and exclude HTML tags during clipboard copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memo-app",
-  "version": "3.0.0 alpha1",
+  "version": "3.0.0",
   "scripts": {
     "start": "parcel src/index.html",
     "build": "parcel build src/index.html --dist-dir public --public-url ./",


### PR DESCRIPTION
1. Improve style removal logic
   - Update the regex to use non-greedy matching when stripping inline `style="…"` attributes  

2. Exclude HTML tags on clipboard copy
   - Modify the copy-to-clipboard handler to strip out any remaining HTML tags, so users get plain text only