### PR TITLE
Ensure history-delete result modal appears above ::before elements

### DIFF
--- a/src/util/modal.ts
+++ b/src/util/modal.ts
@@ -16,7 +16,7 @@ export class Modal {
   }
 
   private initializeModalStyle(): void {
-    const classesToEnsure = ['fixed', 'inset-0', 'flex', 'items-center', 'justify-center', 'bg-black', 'bg-opacity-50', 'hidden'];
+    const classesToEnsure = ['fixed', 'inset-0', 'flex', 'items-center', 'justify-center', 'bg-black', 'bg-opacity-50', 'hidden', 'z-50'];
     classesToEnsure.forEach(cls => {
       if (!this.modalElem.classList.contains(cls)) {
         this.modalElem.classList.add(cls);


### PR DESCRIPTION
This PR fixes an issue where the history-delete result modal is rendered behind elements using the ::before pseudo-element.  

Problem:\
Elements with ::before were creating a new stacking context, causing the modal’s z-index to be insufficient.  
