### PR TITLE
Preserve essential attributes in clearEditorStyles

### DIFF
--- a/src/service/editor.ts
+++ b/src/service/editor.ts
@@ -116,10 +116,19 @@ export const clearEditorStyles = () => {
   const html = editorInstance.getHTML();
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  const preservedAttrs = new Set(['data-task', 'data-task-checked']);
+
+  const tagPreserveMap: Record<string, Set<string>> = {
+    A:    new Set(['href']),
+    IMG:  new Set(['src', 'alt', 'title']),
+    CODE: new Set(['class']),
+    TH:   new Set(['colspan', 'rowspan', 'scope']),
+    TD:   new Set(['colspan', 'rowspan']),
+    LI:   new Set(['data-task', 'data-task-checked']),
+  };
   doc.querySelectorAll('*').forEach(el => {
+    const preserveForTag = tagPreserveMap[el.tagName.toUpperCase()];
     Array.from(el.attributes).forEach(attr => {
-      if (!preservedAttrs.has(attr.name)) {
+      if (!preserveForTag?.has(attr.name)) {
         el.removeAttribute(attr.name);
       }
     });

--- a/tests/service/editor.test.ts
+++ b/tests/service/editor.test.ts
@@ -121,12 +121,80 @@ describe('editor', () => {
   });
 
   describe('clearEditorStyles', () => {
-    it('removes all attributes except preserved ones', () => {
-      const editor = createEditor('');
+    let editor: ReturnType<typeof createEditor>;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="editor"></div>';
+      vi.clearAllMocks();
+      editor = createEditor('');
+    });
+
+    it('removes all attributes on unsupported tags (e.g. <p>)', () => {
       clearEditorStyles();
-      expect(editor.setHTML).toHaveBeenCalled();
+      const cleanedP = (editor.setHTML as any).mock.calls[0][0];
+      expect(cleanedP).toBe('<p>Hello</p>');
+    });
+
+    it('preserves href (and title) on <a> but removes others', () => {
+      const html = '<a href="https://example.com" target="_blank" style="color:red">Link</a>';
+      editor.getHTML = () => html;
+      clearEditorStyles();
       const cleaned = (editor.setHTML as any).mock.calls[0][0];
-      expect(cleaned).toBe('<p data-task="1">Hello</p>');
+      expect(cleaned).toBe('<a href="https://example.com">Link</a>');
+    });
+
+    it('preserves src, alt, title on <img> but removes width/style', () => {
+      const html = '<img src="x.png" alt="desc" title="tit" width="100" style="border:0">';
+      editor.getHTML = () => html;
+      clearEditorStyles();
+      const cleaned = (editor.setHTML as any).mock.calls[0][0];
+      expect(cleaned).toBe('<img src="x.png" alt="desc" title="tit">');
+    });
+
+    it('preserves class on <code> (for syntax highlighting) only', () => {
+      const html = '<code class="language-js" data-info="foo">const x = 1;</code>';
+      editor.getHTML = () => html;
+      clearEditorStyles();
+      const cleaned = (editor.setHTML as any).mock.calls[0][0];
+      expect(cleaned).toBe('<code class="language-js">const x = 1;</code>');
+    });
+
+    it('preserves colspan, rowspan, scope on <th> and <td>', () => {
+      /* ---------- <th> ---------- */
+      const htmlTh = `
+        <table>
+          <thead>
+            <tr>
+              <th colspan="2" rowspan="3" scope="col" data-test="x">H</th>
+            </tr>
+          </thead>
+        </table>`;
+      editor.getHTML = () => htmlTh;
+      clearEditorStyles();
+      let cleaned = (editor.setHTML as any).mock.calls.pop()[0];
+      expect(cleaned).toContain('<th colspan="2" rowspan="3" scope="col">H</th>');
+
+      /* ---------- <td> ---------- */
+      const htmlTd = `
+        <table>
+          <tbody>
+            <tr>
+              <td colspan="5" rowspan="1" data-test="y">D</td>
+            </tr>
+          </tbody>
+        </table>`;
+      editor.getHTML = () => htmlTd;
+      clearEditorStyles();
+      cleaned = (editor.setHTML as any).mock.calls.pop()[0];
+      expect(cleaned).toContain('<td colspan="5" rowspan="1">D</td>');
+    });
+
+    it('preserves data-task and data-task-checked on <li> only', () => {
+      const html = '<li data-task="1" data-task-checked="true" class="foo" style="x">Item</li>';
+      editor.getHTML = () => html;
+      clearEditorStyles();
+      const cleaned = (editor.setHTML as any).mock.calls[0][0];
+      expect(cleaned).toBe('<li data-task="1" data-task-checked="true">Item</li>');
     });
   });
 


### PR DESCRIPTION
This change refactors the clearEditorStyles function to use a tag-based attribute preservation map instead of a global set. For each element, only the attributes defined in tagPreserveMap are retained (e.g. href for `<a>`, src/alt/title for `<img>`, class for `<code>`, colspan/rowspan/scope for `<th>`/`<td>`, data-task/data-task-checked for `<li>`), and all other attributes—including inline styles—are removed.  
 
- Unsupported tags (e.g. `<p>`) have all attributes stripped.
- Each supported tag correctly preserves only its allowed attributes.